### PR TITLE
マイグレーションファイルを修正

### DIFF
--- a/db/migrate/20190706070544_create_user_relationships.rb
+++ b/db/migrate/20190706070544_create_user_relationships.rb
@@ -1,7 +1,7 @@
 class CreateUserRelationships < ActiveRecord::Migration[5.2]
   def change
     create_table :user_relationships do |t|
-      t.references :users, foreign_key: true, null: false
+      t.references :user, foreign_key: true, null: false
       t.references :follower, foreign_key: { to_table: :users }, null: false
       t.timestamps
       t.index [:user_id, :follower_id], unique: true

--- a/db/migrate/20190706080515_create_memos.rb
+++ b/db/migrate/20190706080515_create_memos.rb
@@ -1,7 +1,7 @@
 class CreateMemos < ActiveRecord::Migration[5.2]
   def change
     create_table :memos do |t|
-      t.references :users, foreign_key: true, null: false
+      t.references :user, foreign_key: true, null: false
       t.text :content, null: false
       t.boolean :edit, default: false
       t.timestamps

--- a/db/migrate/20190706081037_create_stocks.rb
+++ b/db/migrate/20190706081037_create_stocks.rb
@@ -1,7 +1,7 @@
 class CreateStocks < ActiveRecord::Migration[5.2]
   def change
     create_table :stocks do |t|
-      t.references :users, foreign_key: true, null: false
+      t.references :user, foreign_key: true, null: false
       t.references :memo, foreign_key: true, null: false
       t.timestamps
 

--- a/db/migrate/20190706081135_create_likes.rb
+++ b/db/migrate/20190706081135_create_likes.rb
@@ -1,7 +1,7 @@
 class CreateLikes < ActiveRecord::Migration[5.2]
   def change
     create_table :likes do |t|
-      t.references :users, foreign_key: true, null: false
+      t.references :user, foreign_key: true, null: false
       t.references :memo, foreign_key: true, null: false
       t.timestamps
 

--- a/db/migrate/20190706081242_create_comments.rb
+++ b/db/migrate/20190706081242_create_comments.rb
@@ -1,7 +1,7 @@
 class CreateComments < ActiveRecord::Migration[5.2]
   def change
     create_table :comments do |t|
-      t.references :users, foreign_key: true
+      t.references :user, foreign_key: true
       t.references :memo, foreign_key: true
       t.text :content, null: false
       t.boolean :edit


### PR DESCRIPTION
git cloneしてmigrateした時に
`t.references :users` と `t.index [:user_id, :follower_id], unique: true` のようにインデックスでuser_idを指定しているファイルで
`PG::UndefinedColumn: ERROR:  column "user_id" does not exist` とエラーが出ました😭

Railsのソースコードのドキュメントには `t.references` の引数は単数形で書いてあるので、
`t.references` の第一引数を複数形から単数形に修正しています🙏

具体的には `t.references :users` → `t.references :user`

ドキュメントは以下です。
https://github.com/rails/rails/blob/b9ca94caea2ca6a6cc09abaffaad67b447134079/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L429-L435

<details>
<summary>migrateした時のログ</summary>

```
$ docker-compose run --rm web rake db:migrate
Starting memotter_db_1 ... done
== 20190706042501 DeviseCreateUsers: migrating ================================
-- create_table(:users)
   -> 0.0337s
-- add_index(:users, :email, {:unique=>true})
   -> 0.0108s
-- add_index(:users, :reset_password_token, {:unique=>true})
   -> 0.0172s
== 20190706042501 DeviseCreateUsers: migrated (0.0645s) =======================

== 20190706044709 AddColumnsToUsers: migrating ================================
-- add_column(:users, :username, :string, {:null=>false})
   -> 0.0038s
== 20190706044709 AddColumnsToUsers: migrated (0.0044s) =======================

== 20190706070544 CreateUserRelationships: migrating ==========================
-- create_table(:user_relationships)
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

PG::UndefinedColumn: ERROR:  column "user_id" does not exist
: CREATE UNIQUE INDEX  "index_user_relationships_on_user_id_and_follower_id" ON "user_relationships"  ("user_id", "follower_id")
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:75:in `async_exec'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:75:in `block (2 levels) in execute'
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:74:in `block in execute'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:581:in `block (2 levels) in log'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:580:in `block in log'
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:571:in `log'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:73:in `execute'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/schema_statements.rb:466:in `add_index'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/schema_statements.rb:315:in `block in create_table'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/schema_statements.rb:314:in `each'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/schema_statements.rb:314:in `create_table'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:871:in `block in method_missing'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:840:in `block in say_with_time'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:840:in `say_with_time'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:860:in `method_missing'
/memotter/db/migrate/20190706070544_create_user_relationships.rb:3:in `change'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:814:in `exec_migration'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:798:in `block (2 levels) in migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:797:in `block in migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:416:in `with_connection'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:796:in `migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:977:in `migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1292:in `block in execute_migration_in_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1343:in `block in ddl_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:267:in `block in transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/transaction.rb:239:in `block in within_new_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/transaction.rb:236:in `within_new_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:267:in `transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/transactions.rb:212:in `transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1343:in `ddl_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1291:in `execute_migration_in_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1263:in `block in migrate_without_lock'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1262:in `each'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1262:in `migrate_without_lock'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1210:in `block in migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1363:in `with_advisory_lock'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1210:in `migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1036:in `up'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1011:in `migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/tasks/database_tasks.rb:172:in `migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/railties/databases.rake:60:in `block (2 levels) in <top (required)>'
/usr/local/bundle/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'

Caused by:
ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column "user_id" does not exist
: CREATE UNIQUE INDEX  "index_user_relationships_on_user_id_and_follower_id" ON "user_relationships"  ("user_id", "follower_id")
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:75:in `async_exec'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:75:in `block (2 levels) in execute'
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:74:in `block in execute'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:581:in `block (2 levels) in log'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:580:in `block in log'
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:571:in `log'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:73:in `execute'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/schema_statements.rb:466:in `add_index'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/schema_statements.rb:315:in `block in create_table'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/schema_statements.rb:314:in `each'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/schema_statements.rb:314:in `create_table'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:871:in `block in method_missing'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:840:in `block in say_with_time'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:840:in `say_with_time'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:860:in `method_missing'
/memotter/db/migrate/20190706070544_create_user_relationships.rb:3:in `change'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:814:in `exec_migration'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:798:in `block (2 levels) in migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:797:in `block in migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:416:in `with_connection'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:796:in `migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:977:in `migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1292:in `block in execute_migration_in_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1343:in `block in ddl_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:267:in `block in transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/transaction.rb:239:in `block in within_new_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/transaction.rb:236:in `within_new_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:267:in `transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/transactions.rb:212:in `transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1343:in `ddl_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1291:in `execute_migration_in_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1263:in `block in migrate_without_lock'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1262:in `each'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1262:in `migrate_without_lock'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1210:in `block in migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1363:in `with_advisory_lock'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1210:in `migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1036:in `up'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1011:in `migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/tasks/database_tasks.rb:172:in `migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/railties/databases.rake:60:in `block (2 levels) in <top (required)>'
/usr/local/bundle/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'

Caused by:
PG::UndefinedColumn: ERROR:  column "user_id" does not exist
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:75:in `async_exec'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:75:in `block (2 levels) in execute'
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:74:in `block in execute'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:581:in `block (2 levels) in log'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:580:in `block in log'
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract_adapter.rb:571:in `log'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/database_statements.rb:73:in `execute'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql/schema_statements.rb:466:in `add_index'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/schema_statements.rb:315:in `block in create_table'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/schema_statements.rb:314:in `each'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/schema_statements.rb:314:in `create_table'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:871:in `block in method_missing'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:840:in `block in say_with_time'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:840:in `say_with_time'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:860:in `method_missing'
/memotter/db/migrate/20190706070544_create_user_relationships.rb:3:in `change'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:814:in `exec_migration'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:798:in `block (2 levels) in migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:797:in `block in migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:416:in `with_connection'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:796:in `migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:977:in `migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1292:in `block in execute_migration_in_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1343:in `block in ddl_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:267:in `block in transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/transaction.rb:239:in `block in within_new_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/transaction.rb:236:in `within_new_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:267:in `transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/transactions.rb:212:in `transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1343:in `ddl_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1291:in `execute_migration_in_transaction'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1263:in `block in migrate_without_lock'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1262:in `each'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1262:in `migrate_without_lock'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1210:in `block in migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1363:in `with_advisory_lock'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1210:in `migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1036:in `up'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/migration.rb:1011:in `migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/tasks/database_tasks.rb:172:in `migrate'
/usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/railties/databases.rake:60:in `block (2 levels) in <top (required)>'
/usr/local/bundle/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

</details>